### PR TITLE
added default case on switch val.(type)

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 )
@@ -53,6 +54,9 @@ func (f *Formatter) Format(entry *logrus.Entry) ([]byte, error) {
 			output = strings.Replace(output, "%"+k+"%", s, 1)
 		case bool:
 			s := strconv.FormatBool(v)
+			output = strings.Replace(output, "%"+k+"%", s, 1)
+		default:
+			s := fmt.Sprintf("%v",v)
 			output = strings.Replace(output, "%"+k+"%", s, 1)
 		}
 	}

--- a/formatter.go
+++ b/formatter.go
@@ -60,6 +60,7 @@ func (f *Formatter) Format(entry *logrus.Entry) ([]byte, error) {
 			output = strings.Replace(output, "%"+k+"%", s, 1)
 		}
 	}
-
+// 	make sure to have a linebreak for each entry
+	output = strings.TrimSuffix(output, "\n") + "\n"
 	return []byte(output), nil
 }


### PR DESCRIPTION
default switch case to convert value to string using `fmt.Sprintf()` for types other than string/int/bool.
